### PR TITLE
#65 - Fixes refresh and updates version

### DIFF
--- a/MIAPackages/MIACoreNetworking/Manager/ArchitectsManager.swift
+++ b/MIAPackages/MIACoreNetworking/Manager/ArchitectsManager.swift
@@ -25,7 +25,7 @@ public class ArchitectsManager {
                 let jsonData = try JSONDecoder().decode(APIArchitects.self, from: data.data)
                 return mapper.map(jsonData)
             } catch {
-                throw ManagerError.unknownError
+                throw ManagerError.unknown
             }
             
         case .failure(let error):
@@ -44,7 +44,7 @@ public class ArchitectsManager {
                 let jsonData = try JSONDecoder().decode(APIArchitectDetail.self, from: data.data)
                 return mapper.map(jsonData)
             } catch {
-                throw ManagerError.unknownError
+                throw ManagerError.unknown
             }
 
         case .failure(let error):

--- a/MIAPackages/MIACoreNetworking/Manager/BuildingsManager.swift
+++ b/MIAPackages/MIACoreNetworking/Manager/BuildingsManager.swift
@@ -29,7 +29,7 @@ public class BuildingsManager {
                 let jsonData = try JSONDecoder().decode(APIBuildings.self, from: data.data)
                 return mapper.map(jsonData)
             } catch {
-                throw ManagerError.unknownError
+                throw ManagerError.unknown
             }
 
         case .failure(let error):
@@ -58,7 +58,7 @@ public class BuildingsManager {
             } catch {
                 
                 Logger.buildingsManager.debug("\(error)")
-                throw ManagerError.unknownError
+                throw ManagerError.unknown
             }
 
         case .failure(let error):
@@ -72,8 +72,8 @@ public class BuildingsManager {
 
 public enum ManagerError: Error {
 
-    case networkError
-    case unknownError
+    case network
+    case unknown
 
     public init(clientError: ClientError) {
         
@@ -81,11 +81,11 @@ public enum ManagerError: Error {
 
         case .HTTPClientError(_),
              .HTTPServerError:
-            self = .networkError
+            self = .network
             
         case .DecodingError(_),
              .InternalError:
-            self = .unknownError
+            self = .unknown
         }
     }
 }

--- a/MIAPackages/MIACoreUI/Components/MIAAsyncImage/MIAAsyncImageViewModel.swift
+++ b/MIAPackages/MIACoreUI/Components/MIAAsyncImage/MIAAsyncImageViewModel.swift
@@ -34,7 +34,7 @@ extension MIAAsyncImageViewModel {
 
         case let .failure(error):
             Logger.client.error("\(error.localizedDescription) for url: \(url?.debugDescription ?? "")")
-            loadingState = .error(.unknownError)
+            loadingState = .error(.unknown)
         }
     }
 }

--- a/MIAPackages/MIACoreUI/Components/MIAErrorView.swift
+++ b/MIAPackages/MIACoreUI/Components/MIAErrorView.swift
@@ -23,10 +23,10 @@ public struct MIAErrorView: View {
             
             switch error {
                 
-            case .networkError:
+            case .network:
                 networkError
                 
-            case .unknownError:
+            case .unknown:
                 unknownError
             }
         }
@@ -67,14 +67,14 @@ extension MIAErrorView {
 
 #Preview("Network Error") {
     
-    MIAErrorView(error: .networkError)
-    MIAErrorView(error: .networkError)
+    MIAErrorView(error: .network)
+    MIAErrorView(error: .network)
         .preferredColorScheme(.dark)
 }
 
 #Preview("Unknown Error") {
     
-    MIAErrorView(error: .unknownError)
-    MIAErrorView(error: .unknownError)
+    MIAErrorView(error: .unknown)
+    MIAErrorView(error: .unknown)
         .preferredColorScheme(.dark)
 }

--- a/MIAapp.xcodeproj/project.pbxproj
+++ b/MIAapp.xcodeproj/project.pbxproj
@@ -281,7 +281,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.modernism-in-architecture.MIAapp.MIAappWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -311,7 +311,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.modernism-in-architecture.MIAapp.MIAappWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.modernism-in-architecture.MIAapp";
 				PRODUCT_NAME = MIA;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -507,7 +507,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.modernism-in-architecture.MIAapp";
 				PRODUCT_NAME = MIA;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MIAapp/View/Architects/ArchitectDetailView/ArchitectDetailViewModel.swift
+++ b/MIAapp/View/Architects/ArchitectDetailView/ArchitectDetailViewModel.swift
@@ -29,7 +29,7 @@ extension ArchitectDetailViewModel {
         } catch let error as ManagerError {
             handleLoadError(error: error)
         } catch {
-            handleLoadError(error: .unknownError)
+            handleLoadError(error: .unknown)
         }
     }
     

--- a/MIAapp/View/Architects/ArchitectsListView/ArchitectsListSuccessView.swift
+++ b/MIAapp/View/Architects/ArchitectsListView/ArchitectsListSuccessView.swift
@@ -34,7 +34,9 @@ struct ArchitectsListSuccessView: View {
     var body: some View {
         
         content
-            .refreshable(action: architectsListViewModel.refresh)
+            .refreshable {
+                await architectsListViewModel.refresh()
+            }
     }
 }
 
@@ -280,3 +282,4 @@ private extension ArchitectsListSuccessView {
         .environmentObject(viewModel)
         .preferredColorScheme(.dark)
 }
+

--- a/MIAapp/View/Architects/ArchitectsListView/ArchitectsListViewModel.swift
+++ b/MIAapp/View/Architects/ArchitectsListView/ArchitectsListViewModel.swift
@@ -15,6 +15,8 @@ class ArchitectsListViewModel: ObservableObject {
     var state: LoadingState<[Architect]> = .loading
     
     private var architectsManager = ArchitectsManager()
+    
+    private var fetchTask: Task<Void, Error>?
 }
 
 extension ArchitectsListViewModel {
@@ -23,18 +25,21 @@ extension ArchitectsListViewModel {
         
         self.state = .loading
         
-        Task {
+        fetchTask?.cancel()
+        fetchTask = Task {
             await fetch()
         }
     }
 }
 
-@MainActor
 extension ArchitectsListViewModel {
     
-    @Sendable
     func refresh() async {
-        await fetch()
+        
+        fetchTask?.cancel()
+        fetchTask = Task {
+            await fetch()
+        }
     }
 }
 
@@ -53,10 +58,20 @@ private extension ArchitectsListViewModel {
     }
     
     private func handle(architects: [Architect]) {
+        
+        if Task.isCancelled {
+            return
+        }
+        
         self.state = .success(architects)
     }
     
     private func handleLoadError(error: ManagerError) {
+        
+        if Task.isCancelled {
+            return
+        }
+        
         self.state = .error(error)
     }
 }

--- a/MIAapp/View/Buildings/BuildingView/BuildingViewModel.swift
+++ b/MIAapp/View/Buildings/BuildingView/BuildingViewModel.swift
@@ -35,7 +35,7 @@ extension BuildingViewModel {
         } catch let error as ManagerError {
             await handleLoadError(error: error)
         } catch {
-            await handleLoadError(error: .unknownError)
+            await handleLoadError(error: .unknown)
         }
     }
 }

--- a/MIAapp/View/Buildings/BuildingsListView/BuildingsListView.swift
+++ b/MIAapp/View/Buildings/BuildingsListView/BuildingsListView.swift
@@ -19,7 +19,9 @@ struct BuildingsListView: View {
     var body: some View {
         
         content
-            .refreshable(action: self.buildingsViewModel.refresh)
+            .refreshable {
+                await buildingsViewModel.refresh()
+            }
     }
 }
 

--- a/MIAapp/View/Buildings/BuildingsListView/BuildingsListViewModel.swift
+++ b/MIAapp/View/Buildings/BuildingsListView/BuildingsListViewModel.swift
@@ -18,6 +18,8 @@ class BuildingsListViewModel: ObservableObject {
     var state: LoadingState<[Building]> = .loading
 
     private var buildingsMangager = BuildingsManager()
+    
+    private var fetchTask: Task<Void, Error>?
 }
 
 // MARK: - Load
@@ -28,20 +30,23 @@ extension BuildingsListViewModel {
         
         state = .loading
         
-        Task {
-            await fetch()
+        fetchTask?.cancel()
+        fetchTask = Task {
+            await performFetch()
         }
     }
 }
 
 // MARK: - Refresh
 
-@MainActor
 extension BuildingsListViewModel {
     
-    @Sendable
     func refresh() async {
-        await fetch()
+        
+        fetchTask?.cancel()
+        fetchTask = Task {
+            await performFetch()
+        }
     }
 }
 
@@ -50,7 +55,7 @@ extension BuildingsListViewModel {
 @MainActor
 private extension BuildingsListViewModel {
     
-    func fetch() async {
+    func performFetch() async {
         
         do {
             
@@ -62,10 +67,20 @@ private extension BuildingsListViewModel {
     }
     
     private func handle(buildings: [Building]) {
+        
+        if Task.isCancelled {
+            return
+        }
+        
         self.state = .success(buildings)
     }
     
     private func handleLoadError(error: ManagerError) {
+        
+        if Task.isCancelled {
+            return
+        }
+        
         self.state = .error(error)
     }
 }
@@ -76,3 +91,4 @@ extension BuildingsListViewModel {
         try await buildingsMangager.getBuildingDetail(for: id)
     }
 }
+


### PR DESCRIPTION
Addresses an issue where refreshing the architects and buildings lists could lead to errors and updates the app's marketing version.

- Ensures that only one fetch task is active at a time by cancelling any existing tasks before starting a new one.
- Updates the MARKETING_VERSION in the project settings from 1.3.1 to 1.3.2.
- Renames `ManagerError.unknownError` to `ManagerError.unknown` for clarity and consistency.

Fixes #65